### PR TITLE
add `keytype` slot for `read.gson()` and `write.gson()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gson
 Title: Base Class and Methods for 'gson' Format
-Version: 0.0.6.991
+Version: 0.0.6.992
 Authors@R: c(
        person("Guangchuang", "Yu",     email = "guangchuangyu@gmail.com", role = c("aut", "cre", "cph"), comment = c(ORCID = "0000-0002-6485-8781"))
        )

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,4 @@
-# DOSE 0.0.6.991
+# DOSE 0.0.6.992
 
++ add `keytype` slot for `read.gson()` and `write.gson()`. (2022-08-5, Wed)
 + add `keytype` slot for GSON object. (2022-07-13, Wed)

--- a/R/IO.R
+++ b/R/IO.R
@@ -38,6 +38,7 @@ read.gson <- function(file) {
        gene2name = gene2name, species = x$species,
        gsname = as.character(x$gsname), version = x$version,
        accessed_date = as.character(x$accessed_date), 
+       keytype = as.character(x$keytype),
        info = as.character(x$info))
 }
 
@@ -64,6 +65,7 @@ as.list.GSON <- function(x,  ...) {
     gsname = x@gsname,
     version = x@version,
     accessed_date = x@accessed_date,
+    keytype = x@keytype,
     info = x@info
   )
 }


### PR DESCRIPTION
老师，我上次PR时添加了slot `keytype`， 但是忘记同时修改 `read.gson()` 和 `write.gson()`了。这次提交给改过来了。