### PR TITLE
fix invalid character error

### DIFF
--- a/R/IO.R
+++ b/R/IO.R
@@ -36,7 +36,7 @@ read.gson <- function(file) {
   
   gson(gsid2gene = gsid2gene, gsid2name = gsid2name,
        gene2name = gene2name, species = x$species,
-       gsname = as.character(x$gsname), version = x$version,
+       gsname = as.character(x$gsname), version = as.character(x$version),
        accessed_date = as.character(x$accessed_date), 
        keytype = as.character(x$keytype),
        info = as.character(x$info))
@@ -50,7 +50,10 @@ read.gson <- function(file) {
 write.gson <- function(x, file = "") {
   res <- jsonlite::toJSON(as.list(x), pretty = TRUE)
   if (file == "") return(res)
-  
+  # for UTF-8 code error
+  res <- iconv(res, "ASCII", "UTF-8")
+  # for lexical error: invalid character inside string.
+  res <- gsub("\\t", " ", res)
   #info <- paste0("R package: gson v=",  packageVersion("gson"), ", ", Sys.Date())
   cat(res, file = file,  sep = "\n")
 }


### PR DESCRIPTION
老师，我这次提交是为了解决三个问题：
（1）有的gson数据没有给version 这个slot赋值，那么x$version就会是一个空的list。而version格式是需要为character或者NULL。因此我转换成了character。
（2）有的注释数据有编码问题，这里我进行了转换：
```r
res <- iconv(res, "ASCII", "UTF-8")
```
（3）有的数据包含 \t 这样的字符，而这样的字符在运行`x <- jsonlite::fromJSON(file)`时会报错。我将\t转为了空格。
```r
res <- gsub("\\t", " ", res)
```